### PR TITLE
Return iterator over Seq<T> instead of Chunks in chunks function

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -254,6 +254,16 @@ macro_rules! array_base {
                 $name(tmp.clone())
             }
         }
+        impl From<Seq<$t>> for $name {
+            fn from(x: Seq<$t>) -> $name {
+                debug_assert!(x.len() <= $l);
+                let mut tmp = [<$t>::default(); $l];
+                for (i, e) in x.iter().enumerate() {
+                    tmp[i] = *e;
+                }
+                $name(tmp.clone())
+            }
+        }
 
         impl $name {
             pub fn random() -> $name {

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -188,12 +188,8 @@ impl<T: Copy + Default> Seq<T> {
         a
     }
 
-    pub fn chunks(&self, chunk_size: usize) -> std::slice::Chunks<'_, T> {
-        self.b.chunks(chunk_size)
-    }
-
-    pub fn chunks_exact(&self, chunk_size: usize) -> std::slice::ChunksExact<'_, T> {
-        self.b.chunks_exact(chunk_size)
+    pub fn chunks<'a>(&'a self, chunk_size: usize) -> impl Iterator<Item = (usize, Seq<T>)> + 'a {
+        self.b.chunks(chunk_size).map(|c| (c.len(), Seq::<T>::from(c)))
     }
 }
 


### PR DESCRIPTION
How about doing this instead of using Rust's Chunks?
(The array change we need for converting the returned sequences to arrays.)