### PR TITLE
Fix invalid struct syntax in poly macros

### DIFF
--- a/src/poly.rs
+++ b/src/poly.rs
@@ -489,7 +489,7 @@ pub struct Poly<T: TRestrictions<T>> {
 #[macro_export]
 macro_rules! poly_n {
     ($name:ident, $t:ty, $n:expr) => {
-        struct $name {};
+        struct $name;
         impl $name {
             fn new(p: &[u128]) -> Poly<$t> {
                 Poly::from_array(p, $n)
@@ -501,7 +501,7 @@ macro_rules! poly_n {
 #[macro_export]
 macro_rules! poly_n_m {
     ($name:ident, $t:ty, $n:expr, $m:expr) => {
-        struct $name {};
+        struct $name;
         impl $name {
             fn new(p: &[u128]) -> Poly<$t> {
                 Poly::new_full($m, p, $n)

--- a/tests/test_poly.rs
+++ b/tests/test_poly.rs
@@ -249,3 +249,6 @@ fn test_poly_factory() {
     let x = R3q::new(&[1, 2, 0, 1]);
     println!("x: {:?}", x);
 }
+
+poly_n!(DummyPolyN, u128, 3);
+poly_n_m!(DummyPolyNM, u128, 3, &[1, 2, 0, 1]);


### PR DESCRIPTION
When invoking `poly_n_m` from a non-function context, you will get the following error:

```
error: macro expansion ignores token `;` and any following
  --> <::hacspec::poly::poly_n_m macros>:3:23
   |
3  |       struct $ name { } ; impl $ name
   |                         ^
   | 
  ::: src/kyber.rs:7:1
```

In non-function context, the syntax `struct Name {};` is invalid. The syntax should be `struct Name;`.

This patch changes the code such that the macros in `poly.rs` use the other syntax. These two cases should be all of them. (I searched with `rg -i 'struct\s+\$(\w+)\s+\{\s*\}'`.)

I added some regression tests for this issue in `poly_tests.rs`.

Cc @cryptojedi.